### PR TITLE
Extra / character in your email URL

### DIFF
--- a/index.php
+++ b/index.php
@@ -310,7 +310,7 @@
 						alt="resume"
 						class="social-logo"
 				/></a>
-				<a href="mailto:/contact@anteste.yo.fr"
+				<a href="mailto:contact@anteste.yo.fr"
 					><img loading="lazy" src="img/mail.svg" alt="mail" class="social-logo"
 				/></a>
 				<a class="my-logo-footer" href="#"


### PR DESCRIPTION
Hello,

I found a problem and bug in your website.
There is an extra `/` character in your email URL.

Maybe this fix this: Change `href="mailto:/contact@anteste.yo.fr"` to `href="mailto:contact@anteste.yo.fr"`

Regards,
Max Base
